### PR TITLE
Enable VoLTE and VoNR

### DIFF
--- a/overlay/packages/apps/CarrierConfig/res/xml/vendor.xml
+++ b/overlay/packages/apps/CarrierConfig/res/xml/vendor.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8' standalone='yes' ?>
+<carrier_config_list>
+    <carrier_config>
+        <boolean name="carrier_volte_available_bool" value="true"/>
+        <boolean name="vendor_hide_volte_settng_ui" value="false"/>
+        <boolean name="hide_lte_plus_data_icon_bool" value="false"/>
+        <boolean name="vonr_enabled_bool" value="true"/>
+        <boolean name="vonr_setting_visibility_bool" value="true"/>
+    </carrier_config>
+</carrier_config_list>


### PR DESCRIPTION
fix China Telecom users unable to use the call function normally